### PR TITLE
Add hashing from bytes

### DIFF
--- a/src/public.rs
+++ b/src/public.rs
@@ -320,6 +320,20 @@ impl PublicKey {
             Err(InternalError::VerifyError.into())
         }
     }
+
+    /// Perform hashing to the group using the Elligator2 map
+    /// This generates a public key that we assume nobody knows its corresponding private key
+    ///
+    /// See https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-10#section-6.7.1
+    pub fn hash_from_bytes<D>(bytes: &[u8]) -> Self
+    where
+        D: Digest<OutputSize = U64> + Default,
+    {
+        let point = EdwardsPoint::hash_from_bytes::<D>(bytes);
+        let compressed = point.compress();
+
+        Self(compressed, point)
+    }
 }
 
 impl Verifier<ed25519::Signature> for PublicKey {

--- a/tests/ed25519.rs
+++ b/tests/ed25519.rs
@@ -143,6 +143,8 @@ mod vectors {
     ];
 
     fn compute_hram(message: &[u8], pub_key: &EdwardsPoint, signature_r: &EdwardsPoint) -> Scalar {
+        use curve25519_dalek::digest::Update;
+
         let k_bytes = Sha512::default()
             .chain(&signature_r.compress().as_bytes())
             .chain(&pub_key.compress().as_bytes()[..])


### PR DESCRIPTION
There is a new use case where we want to create a (fake) public key through hashing so that nobody knows the corresponding private key.

This is similar to 0x addresses for smart contracts.

cc @ws4charlie